### PR TITLE
feat: add send request to gateway tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "apisix-mcp",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "dist/index.js",
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ Configure your AI client (Cursor, Claude, Copilot, etc.) with following settings
     "apisix-mcp": {
       "command": "node",
       "args": [
-        "your-apisix-mcp-path/build/index.js"
+        "your-apisix-mcp-path/dist/index.js"
       ],
       "env": {
         "APISIX_SERVER_HOST": "your-apisix-server-host",

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ https://github.com/user-attachments/assets/081e878c-225e-4ff8-a9c5-5813f4784cfe
 
 - `get_resource`: Retrieve resources by type (routes, services, upstreams, etc.)
 - `delete_resource`: Remove resources by ID
+- `send_request_to_gateway`: Send a request or multiple requests to the APISIX gateway
 
 ### API Resources Operations
 
@@ -56,6 +57,7 @@ Configure your AI client (Cursor, Claude, Copilot, etc.) with following settings
       ],
       "env": {
         "APISIX_SERVER_HOST": "your-apisix-server-host",
+        "APISIX_SERVER_PORT": "your-apisix-server-port",
         "APISIX_ADMIN_API_PORT": "your-apisix-admin-api-port",
         "APISIX_ADMIN_API_PREFIX": "your-apisix-admin-api-prefix",
         "APISIX_ADMIN_KEY": "your-apisix-api-key"
@@ -93,6 +95,7 @@ Configure your AI client (Cursor, Claude, Copilot, etc.) with following settings
       ],
       "env": {
         "APISIX_SERVER_HOST": "your-apisix-server-host",
+        "APISIX_SERVER_PORT": "your-apisix-server-port",
         "APISIX_ADMIN_API_PORT": "your-apisix-admin-api-port",
         "APISIX_ADMIN_API_PREFIX": "your-apisix-admin-api-prefix",
         "APISIX_ADMIN_KEY": "your-apisix-api-key"
@@ -107,8 +110,9 @@ Configure your AI client (Cursor, Claude, Copilot, etc.) with following settings
 | Variable                  | Description                                 | Default Value                      |
 | ------------------------- | ------------------------------------------- | ---------------------------------- |
 | `APISIX_SERVER_HOST`      | Host that have access to your APISIX server | `http://127.0.0.1`                 |
+| `APISIX_SERVER_PORT`      | APISIX server port                          | `9080`                             |
 | `APISIX_ADMIN_API_PORT`   | Admin API port                              | `9180`                             |
 | `APISIX_ADMIN_API_PREFIX` | Admin API prefix                            | `/apisix/admin`                    |
-| `APISIX_ADMIN_KEY`          | Admin API authentication key                | `edd1c9f034335f136f87ad84b625c8f1` |
+| `APISIX_ADMIN_KEY`        | Admin API authentication key                | `edd1c9f034335f136f87ad84b625c8f1` |
 
 To view or modify Admin API configurations in APISIX, refer to the [Admin API](https://apisix.apache.org/docs/apisix/admin-api) documentation.

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,5 @@
 export const APISIX_SERVER_HOST = process.env.APISIX_GATEWAY_URL || "http://127.0.0.1";
+export const APISIX_SERVER_PORT = process.env.APISIX_SERVER_PORT || "9080";
 export const APISIX_ADMIN_API_PORT = process.env.APISIX_ADMIN_API_PORT || "9180";
 export const APISIX_ADMIN_API_PREFIX = process.env.APISIX_ADMIN_API_PREFIX || "/apisix/admin";
 export const APISIX_ADMIN_KEY = process.env.APISIX_ADMIN_KEY || "edd1c9f034335f136f87ad84b625c8f1";

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import setupProtoTools from "./tools/proto.js";
 
 const server = new McpServer({
   name: "apisix-mcp",
-  version: "0.0.4",
+  version: "0.0.5",
 });
 
 setupCommonTools(server);

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -54,7 +54,7 @@ export const SendRequestSchema = z.object({
     method: z.string().describe("request method"),
     data: z.any().optional().describe("request data"),
     headers: z.record(z.string(), z.string()).optional().describe("request headers"),
-    count: z.number().optional().describe("number of requests to send in parallel").default(1),
+    repeatCount: z.number().optional().describe("number of requests to send in parallel").default(1),
   })).describe("array of requests to send in parallel"),
 });
 

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -47,3 +47,15 @@ const STATUSES = {
 } as const;
 
 export const StatusSchema = z.nativeEnum(STATUSES);
+
+export const SendRequestSchema = z.object({
+  requests: z.array(z.object({
+    path: z.string().describe("request path"),
+    method: z.string().describe("request method"),
+    data: z.any().optional().describe("request data"),
+    headers: z.record(z.string(), z.string()).optional().describe("request headers"),
+    count: z.number().optional().describe("number of requests to send in parallel").default(1),
+  })).describe("array of requests to send in parallel"),
+});
+
+

--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -49,7 +49,8 @@ const setupCommonTools = (server: McpServer) => {
 
         return {
           status: response.status,
-          data: response.data
+          data: response.data,
+          headers: response.headers,
         };
       } catch (error) {
         // handle error

--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -60,21 +60,21 @@ const setupCommonTools = (server: McpServer) => {
           return {
             status: axiosError.response.status,
             data: axiosError.response.data || { error: 'Request failed' },
-            headers: axiosError.response.headers,
+            headers: axiosError.response?.headers || {},
           };
         } else if (axiosError.request) {
           // The request was sent but no response was received
           return {
             status: 503, // Use 503 to indicate service is unavailable
             data: { error: 'Gateway is not responding' },
-            headers: axiosError.request.headers,
+            headers: axiosError.request?.headers || {},
           };
         } else {
           // An error occurred while setting up the request
           return {
             status: 500,
             data: { error: axiosError.message || 'Request error' },
-            headers: axiosError.request.headers,
+            headers: axiosError.request?.headers || {},
           };
         }
       }

--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -10,7 +10,7 @@ interface RequestConfig {
   method: AxiosRequestConfig['method'];
   data?: AxiosRequestConfig['data'];
   headers?: AxiosRequestConfig['headers'];
-  count?: number;
+  repeatCount?: number;
 }
 
 const setupCommonTools = (server: McpServer) => {
@@ -59,28 +59,31 @@ const setupCommonTools = (server: McpServer) => {
           // The server responded with an error status code
           return {
             status: axiosError.response.status,
-            data: axiosError.response.data || { error: 'Request failed' }
+            data: axiosError.response.data || { error: 'Request failed' },
+            headers: axiosError.response.headers,
           };
         } else if (axiosError.request) {
           // The request was sent but no response was received
           return {
             status: 503, // Use 503 to indicate service is unavailable
-            data: { error: 'Gateway is not responding' }
+            data: { error: 'Gateway is not responding' },
+            headers: axiosError.request.headers,
           };
         } else {
           // An error occurred while setting up the request
           return {
             status: 500,
-            data: { error: axiosError.message || 'Request error' }
+            data: { error: axiosError.message || 'Request error' },
+            headers: axiosError.request.headers,
           };
         }
       }
     };
 
     const makeRepeatedRequests = async (config: RequestConfig) => {
-      const count = config.count || 1;
-      if (count > 1) {
-        return Promise.all(Array(count).fill(null).map(() => makeRequest(config)));
+      const repeatCount = config.repeatCount || 1;
+      if (repeatCount > 1) {
+        return Promise.all(Array(repeatCount).fill(null).map(() => makeRequest(config)));
       } else {
         return makeRequest(config);
       }

--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -1,7 +1,17 @@
-import { DeleteResourceSchema, GetResourceSchema } from "../schemas/common.js";
+import { DeleteResourceSchema, GetResourceSchema, SendRequestSchema } from "../schemas/common.js";
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import makeAdminAPIRequest from "../adminAPI.js";
+import axios, { AxiosRequestConfig, AxiosError } from "axios";
+import { APISIX_SERVER_PORT, APISIX_SERVER_HOST } from "../env.js";
+
+interface RequestConfig {
+  path: AxiosRequestConfig['url'];
+  method: AxiosRequestConfig['method'];
+  data?: AxiosRequestConfig['data'];
+  headers?: AxiosRequestConfig['headers'];
+  count?: number;
+}
 
 const setupCommonTools = (server: McpServer) => {
   server.tool("get_resource", "Get resource details by ID or list all resources", GetResourceSchema.shape, async (args) => {
@@ -24,6 +34,80 @@ const setupCommonTools = (server: McpServer) => {
 
   server.tool("delete_resource", "Delete a resource by ID", DeleteResourceSchema.shape, async (args) => {
     return await makeAdminAPIRequest(`/${args.type}/${args.id}`, "DELETE");
+  });
+
+  server.tool("send_request_to_gateway", "Send a request or multiple requests to the APISIX gateway", SendRequestSchema.shape, async (args) => {
+    const makeRequest = async (config: RequestConfig) => {
+      try {
+        const response = await axios.request({
+          url: `${APISIX_SERVER_HOST}:${APISIX_SERVER_PORT}${config.path}`,
+          method: config.method,
+          data: config.data,
+          headers: config.headers,
+          timeout: 10000,
+        });
+
+        return {
+          status: response.status,
+          data: response.data
+        };
+      } catch (error) {
+        // handle error
+        const axiosError = error as AxiosError;
+        if (axiosError.response) {
+          // The server responded with an error status code
+          return {
+            status: axiosError.response.status,
+            data: axiosError.response.data || { error: 'Request failed' }
+          };
+        } else if (axiosError.request) {
+          // The request was sent but no response was received
+          return {
+            status: 503, // Use 503 to indicate service is unavailable
+            data: { error: 'Gateway is not responding' }
+          };
+        } else {
+          // An error occurred while setting up the request
+          return {
+            status: 500,
+            data: { error: axiosError.message || 'Request error' }
+          };
+        }
+      }
+    };
+
+    const makeRepeatedRequests = async (config: RequestConfig) => {
+      const count = config.count || 1;
+      if (count > 1) {
+        return Promise.all(Array(count).fill(null).map(() => makeRequest(config)));
+      } else {
+        return makeRequest(config);
+      }
+    };
+
+    let results = [];
+    results = await Promise.all(args.requests.map(req => makeRepeatedRequests(req)));
+
+
+    // Flatten results if needed and count
+    const flatResults = results.flat();
+    const singleResults = flatResults.filter(r => !Array.isArray(r));
+    const multiResults = flatResults.filter(r => Array.isArray(r)).flat();
+    const allResults = [...singleResults, ...multiResults];
+
+    return {
+      content: [{
+        type: "text" as const,
+        text: JSON.stringify({
+          results: allResults,
+          summary: {
+            total: allResults.length,
+            successful: allResults.filter(r => r.status >= 200 && r.status < 300).length,
+            failed: allResults.filter(r => r.status >= 400).length
+          }
+        }, null, 2)
+      }]
+    };
   });
 };
 


### PR DESCRIPTION
Add a new tool `send request to gateway`, which is used to send a request or multiple requests to the APISIX gateway, LLM can call the tool to verify the configuration result after editing APISIX resources, such as adding routes or configuring plugins.

Example of usage scenarios:  
*“Create a route to https://httpbin.org with an id of `httpbin` and a proxy prefix of `/ip`, then **send a request to the gateway to verify that the configuration is successful**”*